### PR TITLE
Resolve: Invalid KeyId in CreateToken when using a X509Certificate2 w…

### DIFF
--- a/src/ITfoxtec.Identity.csproj
+++ b/src/ITfoxtec.Identity.csproj
@@ -21,10 +21,10 @@
 		</Description>
 		<PackageTags>OAuth 2.0 OpenID Connect OIDC</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<Version>2.6.0</Version>
+		<Version>2.7.0</Version>
 		<PackageIconUrl>https://itfoxtec.com/favicon.ico</PackageIconUrl>
-		<AssemblyVersion>2.6.0</AssemblyVersion>
-		<FileVersion>2.6.0</FileVersion>
+		<AssemblyVersion>2.7.0</AssemblyVersion>
+		<FileVersion>2.7.0</FileVersion>
 		<PackageProjectUrl>https://github.com/ITfoxtec/ITfoxtec.Identity</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/ITfoxtec/ITfoxtec.Identity</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/Tokens/JwtHandler.cs
+++ b/src/Tokens/JwtHandler.cs
@@ -40,7 +40,8 @@ namespace ITfoxtec.Identity.Tokens
             string algorithm = IdentityConstants.Algorithms.Asymmetric.RS256, string typ = IdentityConstants.JwtHeaders.MediaTypes.Jwt)
         {
             if (certificate == null) throw new ArgumentNullException(nameof(certificate));
-            return CreateToken(new MSTokens.X509SecurityKey(certificate), issuer, audiences, claims, issuedAt: issuedAt, beforeIn: beforeIn, expiresIn: expiresIn, algorithm: algorithm, typ: typ);
+            var publicKey = certificate.ToFTJsonWebKey();
+            return CreateToken(new MSTokens.X509SecurityKey(certificate, publicKey.Kid), issuer, audiences, claims, issuedAt: issuedAt, beforeIn: beforeIn, expiresIn: expiresIn, algorithm: algorithm, typ: typ);
         }
 
         /// <summary>


### PR DESCRIPTION
…hich is converted to X509SecurityKey.