### PR TITLE
Add the `X5tS256` value in `JsonWebKey` according to: The "x5t" (X.50…

### DIFF
--- a/src/Extensions/FTJsonWebKeyExtensions.cs
+++ b/src/Extensions/FTJsonWebKeyExtensions.cs
@@ -22,8 +22,9 @@ namespace ITfoxtec.Identity
             var publicKey = new JsonWebKey
             {
                 Kty = jwk.Kty,
-                X5t = jwk.X5t,
                 Kid = jwk.Kid,
+                X5t = jwk.X5t,
+                X5tS256 = jwk.X5tS256,
                 N = jwk.N,
                 E = jwk.E
             };
@@ -106,8 +107,9 @@ namespace ITfoxtec.Identity
                 }
             }
 
-            jwkResult.X5t = jwk.X5t;
             jwkResult.Kid = jwk.Kid;
+            jwkResult.X5t = jwk.X5t;
+            jwkResult.X5tS256 = jwk.X5tS256;
 
             jwkResult.N = jwk.N;
             jwkResult.E = jwk.E;

--- a/src/Extensions/MSJsonWebKeyExtensions.cs
+++ b/src/Extensions/MSJsonWebKeyExtensions.cs
@@ -107,8 +107,18 @@ namespace ITfoxtec.Identity
                 }
             }
 
-            jwkResult.X5t = jwk.X5t;
             jwkResult.Kid = jwk.Kid;
+            jwkResult.X5t = jwk.Kid;
+
+            var certificate = jwk.X5c?.FirstOrDefault();
+            if (certificate != null)
+            {
+                jwkResult.X5tS256 = Convert.FromBase64String(certificate).GetCertificateX5tS256();
+            }
+            else
+            {
+                jwkResult.X5tS256 = jwk.X5tS256;
+            }
 
             jwkResult.N = jwk.N;
             jwkResult.E = jwk.E;

--- a/src/ITfoxtec.Identity.csproj
+++ b/src/ITfoxtec.Identity.csproj
@@ -21,10 +21,10 @@
 		</Description>
 		<PackageTags>OAuth 2.0 OpenID Connect OIDC</PackageTags>
 		<NeutralLanguage>en-US</NeutralLanguage>
-		<Version>2.8.0</Version>
+		<Version>2.9.1</Version>
 		<PackageIconUrl>https://itfoxtec.com/favicon.ico</PackageIconUrl>
-		<AssemblyVersion>2.8.0</AssemblyVersion>
-		<FileVersion>2.8.0</FileVersion>
+		<AssemblyVersion>2.9.1</AssemblyVersion>
+		<FileVersion>2.9.1</FileVersion>
 		<PackageProjectUrl>https://github.com/ITfoxtec/ITfoxtec.Identity</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/ITfoxtec/ITfoxtec.Identity</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/Models/JsonWebKey.cs
+++ b/src/Models/JsonWebKey.cs
@@ -66,7 +66,7 @@ namespace ITfoxtec.Identity.Models
         public string X5t { get; set; }
 
         /// <summary>
-        /// The "x5t" (X.509 certificate SHA-256 thumbprint) parameter is a base64url-encoded SHA-1 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [RFC5280]. 
+        /// The "x5t" (X.509 certificate SHA-256 thumbprint) parameter is a base64url-encoded SHA-256 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [RFC5280]. 
         /// Use of this member is OPTIONAL.
         /// </summary>
         [JsonProperty(PropertyName = "x5t#S256")]


### PR DESCRIPTION
…9 certificate SHA-256 thumbprint) parameter is a base64url-encoded SHA-256 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [RFC5280].

Change the `X5c` value in `JsonWebKey` to be: The "x5t" (X.509 certificate SHA-1 thumbprint) parameter is a base64url-encoded SHA-1 thumbprint (a.k.a. digest) of the DER encoding of an X.509 certificate [RFC5280].